### PR TITLE
Manage binaries with pip and improve cross-platform support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-bin/*.exe filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ dist/
 build/
 *.spec
 
-# unused executables
-bin/ffplay.exe
-bin/ffprobe.exe
+# unused executables dir
+bin/**

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@ build/
 *.spec
 
 # unused executables dir
-bin/**
+bin/
+
+# github workflows will fail because Youtube flags the IP address as a bot
+.github/workflows/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # simple_ytdl
 [![Code style](https://img.shields.io/badge/code_style-black-black?style=for-the-badge)](https://github.com/psf/black)
 [![Commit activity](https://img.shields.io/github/commit-activity/t/Jurassic001/simple_ytdl?style=for-the-badge&logo=github)](https://github.com/Jurassic001/simple_ytdl/activity)
-<!-- Future testing results badge
-[![GitHub branch check runs](https://img.shields.io/github/check-runs/Jurassic001/simple_ytdl/main?style=for-the-badge)](https://github.com/Jurassic001/simple_ytdl/actions) -->
 
 ### An easy-to-use, text-based program for downloading Youtube videos at high fidelity, utilizing [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [FFmpeg](https://www.ffmpeg.org).
 
@@ -36,7 +34,7 @@ I wanted to extend this simplicity to other users, so I redesigned this program 
 ## Future plans
 * Add a GUI to the program
 * Add more download location options
-* Add tests
+* Add workflow tests (need to circumvent Youtube bot checks)
 
 ## Legal
 ### Disclaimer

--- a/bin/ffmpeg.exe
+++ b/bin/ffmpeg.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c95fd4a7551d207b06593a1ff2dbc7c3ac512feda8765e743a693dc8717e4db
-size 121958912

--- a/bin/yt-dlp.exe
+++ b/bin/yt-dlp.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0410973c9914fe4e7940199a9ab91c1f83ca19f822571f825172a4d6d92ad59b
-size 18778116

--- a/main.py
+++ b/main.py
@@ -22,6 +22,11 @@ class simple_ytdl:
         self.clear = lambda: os.system("cls")  # Clear the console
         self.isVideo: bool = True  # Download format: True - mp4, False - mp3
 
+        if sys.platform.startswith("linux"):
+            self.paste = lambda: subprocess.check_output("xclip -selection clipboard -o", shell=True).decode().strip()
+        else:
+            self.paste = pyperclip.paste
+
     def downloadVideo(self, link: str, vidName: str) -> None:
         """Download the target video
 
@@ -104,7 +109,15 @@ class simple_ytdl:
             self.clear()
             print("Press Enter once you've copied the URL")
             kb.wait("Enter")
-            url = pyperclip.paste()
+            if sys.platform == "win32":
+                url = pyperclip.paste()
+            elif sys.platform == "linux":
+                pyperclip.set_clipboard("xclip")
+            elif sys.platform == "darwin":
+                pyperclip.set_clipboard("pbobjc")
+            else:  # Unsupported OS
+                print("Unsupported OS")
+                sys.exit()
             # Look for a valid URL
             if url.startswith("http"):
                 self.configDownload(url)

--- a/main.py
+++ b/main.py
@@ -1,14 +1,14 @@
+import argparse
 import os
 import subprocess
 import sys
 import time
 
-import keyboard as kb
 import pyperclip
 
 
 class simple_ytdl:
-    def __init__(self) -> None:
+    def __init__(self, skip: bool, skip_val: str) -> None:
         self.EXT_DICT: dict[bool, str] = {
             True: "mp4",
             False: "mp3",
@@ -19,13 +19,25 @@ class simple_ytdl:
             subprocess.CalledProcessError: "Invalid URL or the video cannot be found.",
         }  # Dictionary of error messages that correspond to the exception
 
-        self.clear = lambda: os.system("cls")  # Clear the console
+        self.clear = lambda: os.system("cls" if os.name == "nt" else "clear")  # Clear the console
         self.isVideo: bool = True  # Download format: True - mp4, False - mp3
 
-        if sys.platform.startswith("linux"):
-            self.paste = lambda: subprocess.check_output("xclip -selection clipboard -o", shell=True).decode().strip()
+        self.skip_prompts: bool = skip  # Skip input prompts
+        self.prompt_skip_val: str = skip_val  # Value to return when skipping prompts
+
+    def input(self, prompt: str = "") -> str:
+        """Prompt the user for input, or skip the prompt if the relevant argument is applied
+
+        Args:
+            prompt (str): The prompt to display to the user
+
+        Returns:
+            str: The user's input, or the value returned when skipping prompts
+        """
+        if self.skip_prompts:
+            return self.prompt_skip_val
         else:
-            self.paste = pyperclip.paste
+            return input(prompt).strip().lower()
 
     def downloadVideo(self, link: str, vidName: str) -> None:
         """Download the target video
@@ -34,7 +46,7 @@ class simple_ytdl:
             link (str): The URL of the media that you want to download
             vidName (str): The name of the media that you want to download
         """
-        # Print the name of the to-be downloaded video and it's destination
+        # Print the name of the to-be downloaded video and its destination
         self.clear()
         targ_folder = "Videos" if self.isVideo else "Music"
         print(f"Downloading: {vidName} to your {targ_folder} folder\n")
@@ -67,9 +79,8 @@ class simple_ytdl:
                 ]
             )
         # Make sure the user sees the successful/failed download status before closing the console.
-        print("\nPress Enter to exit the program")
-        kb.wait("Enter")
-        sys.exit()
+        self.input("\nPress Enter to exit the program")
+        sys.exit(0)
 
     def configDownload(self, link: str) -> None:
         """Here the user can see the video title, choose to download as an mp4 or mp3, and continue or go back
@@ -78,37 +89,34 @@ class simple_ytdl:
             link (str): The URL of the media that you want to download
         """
         self.clear()
-        print("Processing the URL...\n")
+        print("Processing the URL...", end="\n\n")
         try:
             videoName = (subprocess.check_output(["yt-dlp", "-O", "%(title)s", link], text=True, timeout=10)).strip()
         except Exception as e:
             err_msg = self.ERROR_MSG.get(type(e), "An unknown error occurred.")
-            print(f"\n{err_msg} Press Enter to try again.")
-            kb.wait("enter")
+            self.input(f"\n{err_msg} Press Enter to try again. ")
             return
         while True:
             self.clear()
             print(f"Selected video: {videoName}")
-            print(f"Downloading as an {self.EXT_DICT[self.isVideo]}")
-            print(f"Press M to switch to {self.EXT_DICT[not self.isVideo]}\n")
-            print("Press Enter to start the download")
-            print("Press Backspace to select another video")
+            print(f"Downloading as an {self.EXT_DICT[self.isVideo]}", end="\n\n")
+
+            print("Type anything to confirm and download the video")
+            print(f'Type "S" to switch to {self.EXT_DICT[not self.isVideo]}')
+            print('Type "N" to go back')
             time.sleep(0.5)
-            while True:
-                if kb.is_pressed("enter"):
-                    self.downloadVideo(link, videoName)
-                elif kb.is_pressed("m"):
-                    self.isVideo = not self.isVideo
-                    break
-                elif kb.is_pressed("backspace"):
-                    return
+            user_input = self.input()
+            if user_input.startswith("s"):
+                self.isVideo = not self.isVideo
+            elif user_input.startswith("n"):
+                return
+            else:
+                self.downloadVideo(link, videoName)
 
     def main(self) -> None:
         while True:
             # Print instructions and wait for user input
             self.clear()
-            print("Press Enter once you've copied the URL")
-            kb.wait("Enter")
             if sys.platform == "win32":
                 url = pyperclip.paste()
             elif sys.platform == "linux":
@@ -122,17 +130,30 @@ class simple_ytdl:
             if url.startswith("http"):
                 self.configDownload(url)
             else:
-                # Warn the user if a URL isn't detected and give them the option to abandon/continue the download.
-                print("\nValid URL not found. Do you want to continue? (Yes/Y/Enter or No/N/Backspace)")
+                # Warn the user if a URL isn't detected and give them the option to continue/retry/abandon the download.
+                valid_fail = self.input("\nValid URL not found. Do you want to continue? (y/n) ")
                 time.sleep(0.5)
-                while True:
-                    if kb.is_pressed("y") or kb.is_pressed("enter"):
-                        self.configDownload(url)
-                        break
-                    elif kb.is_pressed("n") or kb.is_pressed("backspace"):
-                        break
+                if valid_fail.startswith("n"):
+                    continue
+                else:
+                    self.configDownload(url)
 
 
 if __name__ == "__main__":
-    download = simple_ytdl()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip",
+        action="store_true",
+        default=False,
+        help="Skip input prompts and use default values",
+    )
+    parser.add_argument(
+        "--skip-val",
+        type=str,
+        default="",
+        help="Value to return when skipping prompts",
+    )
+    args = parser.parse_args()
+
+    download = simple_ytdl(args.skip, args.skip_val)
     download.main()

--- a/main.py
+++ b/main.py
@@ -20,10 +20,20 @@ class simple_ytdl:
         }  # Dictionary of error messages that correspond to the exception
 
         self.clear = lambda: os.system("cls" if os.name == "nt" else "clear")  # Clear the console
-        self.isVideo: bool = True  # Download format: True - mp4, False - mp3
 
+        self.isVideo: bool = True  # Download format: True - mp4, False - mp3
         self.skip_prompts: bool = skip  # Skip input prompts
         self.prompt_skip_val: str = skip_val  # Value to return when skipping prompts
+
+        if sys.platform == "win32":
+            pyperclip.set_clipboard("windows")
+        elif sys.platform == "linux":
+            pyperclip.set_clipboard("xclip")
+        elif sys.platform == "darwin":
+            pyperclip.set_clipboard("pbobjc")
+        else:  # Unsupported OS
+            print("Unsupported OS")
+            sys.exit(1)
 
     def input(self, prompt: str = "") -> str:
         """Prompt the user for input, or skip the prompt if the relevant argument is applied
@@ -115,23 +125,16 @@ class simple_ytdl:
 
     def main(self) -> None:
         while True:
-            # Print instructions and wait for user input
+            # clear terminal and get clipboard content
             self.clear()
-            if sys.platform == "win32":
-                url = pyperclip.paste()
-            elif sys.platform == "linux":
-                pyperclip.set_clipboard("xclip")
-            elif sys.platform == "darwin":
-                pyperclip.set_clipboard("pbobjc")
-            else:  # Unsupported OS
-                print("Unsupported OS")
-                sys.exit()
-            # Look for a valid URL
+            print("Checking user clipboard for a URL...", end="\n\n")
+            url = pyperclip.paste()
+            # valid URL check
             if url.startswith("http"):
                 self.configDownload(url)
             else:
-                # Warn the user if a URL isn't detected and give them the option to continue/retry/abandon the download.
-                valid_fail = self.input("\nValid URL not found. Do you want to continue? (y/n) ")
+                # Warn the user if a URL isn't detected and give them the option to continue anyways/retry the download.
+                valid_fail = self.input("Valid URL not found. Do you want to continue? (y/n) ")
                 time.sleep(0.5)
                 if valid_fail.startswith("n"):
                     continue

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import pyperclip
 
 
 class simple_ytdl:
-    def __init__(self, skip: bool, skip_val: str) -> None:
+    def __init__(self, skip: bool, skip_val: str, arg_url: str) -> None:
         self.EXT_DICT: dict[bool, str] = {
             True: "mp4",
             False: "mp3",
@@ -34,6 +34,9 @@ class simple_ytdl:
         else:  # Unsupported OS
             print("Unsupported OS")
             sys.exit(1)
+
+        if arg_url != "none":
+            pyperclip.copy(arg_url)
 
     def input(self, prompt: str = "") -> str:
         """Prompt the user for input, or skip the prompt if the relevant argument is applied
@@ -156,7 +159,13 @@ if __name__ == "__main__":
         default="",
         help="Value to return when skipping prompts",
     )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="none",
+        help="URL of the video to download",
+    )
     args = parser.parse_args()
 
-    download = simple_ytdl(args.skip, args.skip_val)
+    download = simple_ytdl(args.skip, args.skip_val, args.url)
     download.main()

--- a/main.py
+++ b/main.py
@@ -19,9 +19,6 @@ class simple_ytdl:
             subprocess.CalledProcessError: "Invalid URL or the video cannot be found.",
         }  # Dictionary of error messages that correspond to the exception
 
-        self.YTDL_PATH: str = os.path.join(os.path.dirname(__file__), "bin/yt-dlp.exe")  # Path to the yt-dlp executable
-        self.FFMPEG_PATH: str = os.path.join(os.path.dirname(__file__), "bin/ffmpeg.exe")  # Path to the ffmpeg executable
-
         self.clear = lambda: os.system("cls")  # Clear the console
         self.isVideo: bool = True  # Download format: True - mp4, False - mp3
 
@@ -42,7 +39,7 @@ class simple_ytdl:
         if self.isVideo:
             subprocess.run(
                 [
-                    f"{self.YTDL_PATH}",
+                    "yt-dlp",
                     "-f bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b",
                     "-o~/Videos/%(title)s.%(ext)s",
                     link,
@@ -51,9 +48,7 @@ class simple_ytdl:
         else:
             subprocess.run(
                 [
-                    f"{self.YTDL_PATH}",
-                    "--ffmpeg-location",
-                    f"{self.FFMPEG_PATH}",
+                    "yt-dlp",
                     "-x",
                     "--audio-format",
                     "mp3",
@@ -75,7 +70,7 @@ class simple_ytdl:
         self.clear()
         print("Processing the URL...\n")
         try:
-            videoName = (subprocess.check_output([f"{self.YTDL_PATH}", '-O"%(title)s"', link], text=True, timeout=10)).strip()
+            videoName = (subprocess.check_output(["yt-dlp", '-O"%(title)s"', link], text=True, timeout=10)).strip()
         except Exception as e:
             err_msg = self.ERROR_MSG.get(type(e), "An unknown error occurred.")
             print(f"\n{err_msg} Press Enter to try again.")

--- a/main.py
+++ b/main.py
@@ -40,8 +40,10 @@ class simple_ytdl:
             subprocess.run(
                 [
                     "yt-dlp",
-                    "-f bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b",
-                    "-o~/Videos/%(title)s.%(ext)s",
+                    "--format",
+                    "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/b",
+                    "-o",
+                    os.path.expanduser("~/Videos/%(title)s.%(ext)s"),
                     link,
                 ]
             )
@@ -49,10 +51,13 @@ class simple_ytdl:
             subprocess.run(
                 [
                     "yt-dlp",
-                    "-x",
+                    "--extract-audio",
                     "--audio-format",
                     "mp3",
-                    "-o~/Music/%(title)s.%(ext)s",
+                    "--audio-quality",
+                    "0",
+                    "-o",
+                    os.path.expanduser("~/Music/%(title)s.%(ext)s"),
                     link,
                 ]
             )
@@ -70,7 +75,7 @@ class simple_ytdl:
         self.clear()
         print("Processing the URL...\n")
         try:
-            videoName = (subprocess.check_output(["yt-dlp", '-O"%(title)s"', link], text=True, timeout=10)).strip()
+            videoName = (subprocess.check_output(["yt-dlp", "-O", "%(title)s", link], text=True, timeout=10)).strip()
         except Exception as e:
             err_msg = self.ERROR_MSG.get(type(e), "An unknown error occurred.")
             print(f"\n{err_msg} Press Enter to try again.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+ffmpeg==1.4
+ffprobe==0.5
 keyboard==0.13.5
 pre-commit==3.8.0
 pyinstaller==6.10.0
 pyperclip==1.9.0
+yt-dlp==2024.10.7

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -14,16 +14,12 @@ def build(clean: bool, simple: bool) -> None:
     if simple:
         executable_name = "simple_ytdl"
     else:
-        executable_name = f"simple_ytdl.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True).strip()}"
+        executable_name = f"simple_ytdl.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True, cwd=WORKING_DIR).strip()}"
 
     subprocess.run(
         [
             "pyinstaller",
             "--onefile",
-            "--add-binary",
-            f"{WORKING_DIR}/bin/yt-dlp.exe;bin",
-            "--add-binary",
-            f"{WORKING_DIR}/bin/ffmpeg.exe;bin",
             "--distpath",
             "./pyinstaller/dist",
             "--workpath",
@@ -33,7 +29,7 @@ def build(clean: bool, simple: bool) -> None:
             "--name",
             executable_name,
             "--icon",
-            f"{WORKING_DIR}/assets/ytdl.ico",
+            WORKING_DIR + "/assets/ytdl.ico",
             "main.py",
         ],
         cwd=WORKING_DIR,

--- a/scripts/install_reqs.py
+++ b/scripts/install_reqs.py
@@ -74,12 +74,6 @@ def main(strict: bool) -> None:
         check=strict,
         cwd=ROOT_DIR,
     )
-    # Setup Git LFS
-    subprocess.run(
-        ["git", "lfs", "install"],
-        check=strict,
-        cwd=ROOT_DIR,
-    )
     print_with_sidebars("Requirement installation/setup successful", GREEN)
     sys.exit(0)
 


### PR DESCRIPTION
## Major changes
### Handle binaries with pip instead of bundling them into the executable:
In the past, `yt-dlp` and `ffmpeg` were bundled as binaries into the `simple_ytdl` executable. This was a bloated, difficult to manage approach with compatibility issues. After this pull request, `yt-dlp` and its dependencies (`ffmpeg` and `ffprobe`) will be handled by pip, as a part of `requirements.txt`.

* Added `yt-dlp` and dependencies to `requirements.txt`.
* Replaced direct calls to `yt-dlp` and `ffmpeg` executables with more flexible keyword calls, removing hardcoded paths. 
* Removed references to the old binaries in the `build.py` script.
* Removed everything related to git LFS (large file system), since we don't need to include the binaries in the repository itself anymore.

### Improve cross-platform support:

* Enhanced `main.py` to handle system clipboard based on the OS.
* Improved input handling by replacing the `keyboard` library with a slightly altered Python input function that supports skipping prompts. Keystroke readers like `keyboard` and [`pyinput`](https://pypi.org/project/pynput/) aren't very friendly to CLI-only systems. I'll re-add keystrokes eventually, maybe in the form of a GUI.

## Minor changes

* Added command-line arguments for skipping prompts and specifying a URL directly, intended for automated testing.
* Format subprocess calls with standard syntax conventions.
* Updated `README.md` to reflect changes in future plans for workflow-based testing.
* Modified the `build.py` script to ensure the correct current working directory is used for subprocess calls.