### PR TITLE
Add workflow to create draft release containing program binaries (& other misc stuff)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
+# .github/dependabot.yml
+
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       default:
         patterns:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,18 +1,22 @@
 # .github/release.yml
 
 changelog:
-  exclude:
-    authors:
-      - dependabot[bot]
-      - pre-commit-ci[bot]
   categories:
     - title: Major Changes
       labels:
         - enhancement
+        - major
     - title: Minor Changes
       labels:
-        - "!bug"
-        - "!enhancement"
+        - minor
+        - refactor
+        - documentation
     - title: Bugfixes
       labels:
         - bug
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Other
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+      - pre-commit-ci[bot]
+  categories:
+    - title: Major Changes
+      labels:
+        - enhancement
+    - title: Minor Changes
+      labels:
+        - "!bug"
+        - "!enhancement"
+    - title: Bugfixes
+      labels:
+        - bug

--- a/.github/workflows/label-precommit-prs.yml
+++ b/.github/workflows/label-precommit-prs.yml
@@ -1,0 +1,17 @@
+name: Label Pre-commit PRs
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  label-precommit-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Label PRs from pre-commit-ci[bot]
+      if: github.actor == 'pre-commit-ci[bot]'
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: dependencies

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,7 +27,7 @@ jobs:
       run: python scripts/build.py -cs
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_windows
         path: ./pyinstaller/dist/simple_ytdl_win32.exe
@@ -52,7 +52,7 @@ jobs:
       run: python scripts/build.py -cs
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_linux
         path: ./pyinstaller/dist/simple_ytdl_linux
@@ -77,7 +77,7 @@ jobs:
       run: python scripts/build.py -cs
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_macos
         path: ./pyinstaller/dist/simple_ytdl_macos
@@ -89,17 +89,17 @@ jobs:
 
     steps:
     - name: Download Windows executable
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_windows
 
     - name: Download Linux executable
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_linux
 
     - name: Download MacOS executable
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_macos
 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,117 @@
+name: Build and Release (Windows, Ubuntu, macOS)
+# Build and release the simple_ytdl executable on Windows, Ubuntu, and macOS when a tag is pushed
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  # region Build Win exe
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+
+    - name: Install Python Packages
+      run: python scripts/install_reqs.py
+
+    - name: Build simple_ytdl.exe
+      run: python scripts/build.py -cs
+
+    - name: Upload executable
+      uses: actions/upload-artifact@v2
+      with:
+        name: simple_ytdl_windows
+        path: ./pyinstaller/dist/simple_ytdl_win32.exe
+
+  # region Build Linux exe
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+
+    - name: Install Python Packages
+      run: python scripts/install_reqs.py
+
+    - name: Build simple_ytdl
+      run: python scripts/build.py -cs
+
+    - name: Upload executable
+      uses: actions/upload-artifact@v2
+      with:
+        name: simple_ytdl_linux
+        path: ./pyinstaller/dist/simple_ytdl_linux
+
+  # region Build MacOS exe
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+
+    - name: Install Python Packages
+      run: python scripts/install_reqs.py
+
+    - name: Build simple_ytdl
+      run: python scripts/build.py -cs
+
+    - name: Upload executable
+      uses: actions/upload-artifact@v2
+      with:
+        name: simple_ytdl_macos
+        path: ./pyinstaller/dist/simple_ytdl_macos
+
+  # region Create a draft release
+  release:
+    needs: [build-windows, build-linux, build-macos]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download Windows executable
+      uses: actions/download-artifact@v2
+      with:
+        name: simple_ytdl_windows
+
+    - name: Download Linux executable
+      uses: actions/download-artifact@v2
+      with:
+        name: simple_ytdl_linux
+
+    - name: Download MacOS executable
+      uses: actions/download-artifact@v2
+      with:
+        name: simple_ytdl_macos
+
+    - name: Create a draft release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        draft: true
+        prerelease: false
+        files: |
+          simple_ytdl_win32.exe
+          simple_ytdl_linux
+          simple_ytdl_macos

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
@@ -66,7 +66,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
 
@@ -38,10 +38,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
 
@@ -63,10 +63,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
 
@@ -108,7 +108,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
+        tag_name: ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
         draft: true
         prerelease: false
         files: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ build/
 # unused executables dir
 bin/
 
-# github workflows will fail because Youtube flags the IP address as a bot
-.github/workflows/
+# testing workflows will fail because Youtube flags the IP address as a bot
+.github/workflows/test-*.yml

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # simple_ytdl
-[![Code style](https://img.shields.io/badge/code_style-black-black?style=for-the-badge)](https://github.com/psf/black)
-[![Commit activity](https://img.shields.io/github/commit-activity/t/Jurassic001/simple_ytdl?style=for-the-badge&logo=github)](https://github.com/Jurassic001/simple_ytdl/activity)
+[![Code style](https://img.shields.io/badge/code_style-black-black?style=flat-square)](https://github.com/psf/black)
+[![Commit activity](https://img.shields.io/github/commit-activity/t/Jurassic001/simple_ytdl?style=flat-square)](https://github.com/Jurassic001/simple_ytdl/activity)
+[![GitHub Release](https://img.shields.io/github/v/release/Jurassic001/simple_ytdl?style=flat-square)](https://github.com/Jurassic001/simple_ytdl/releases/latest)
+[![GitHub License](https://img.shields.io/github/license/Jurassic001/simple_ytdl?style=flat-square)](LICENSE)
 
 ### An easy-to-use, text-based program for downloading Youtube videos at high fidelity, utilizing [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [FFmpeg](https://www.ffmpeg.org).
 
 ## How to use
 ### Requirements
-This program is compiled on a Windows 10/11 system, so I can only guarantee that it will work on Windows 10/11. If you are using a different operating system, feel free to give it a test run and let me know if it works.
+#### `Windows & MacOS`
+None! The executable file contains all the necessary dependencies to run the program.
+
+#### `Linux`
+You need to have `xclip` installed on your system. You can install it using the following command:
+```bash
+sudo apt-get install xclip
+```
 
 ### Installation
-Download the latest executable (.exe) file in [releases](https://github.com/Jurassic001/simple_ytdl/releases). <br/>
+Download the executable (.exe) file for your operating system in [releases](https://github.com/Jurassic001/simple_ytdl/releases/latest). <br/>
 That's it! You can now run the program and easily download videos at high quality!
 
 ### Program Usage
@@ -41,4 +50,4 @@ I wanted to extend this simplicity to other users, so I redesigned this program 
 This program is not affiliated with Youtube, yt-dlp, or FFmpeg. It is an independent project that utilizes these tools to download media. The program is not intended for illegal use, and I am not responsible for any misuse of this program.
 
 ### License
-You may view the repository's license [here](LICENSE).
+This program is licensed under the MIT License. You may view the repository's license [here](LICENSE).

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import sys
 
 WORKING_DIR: str = os.path.join(os.path.dirname(os.path.dirname(__file__)))
 
@@ -11,10 +12,13 @@ def build(clean: bool, simple: bool) -> None:
     if clean:
         shutil.rmtree(os.path.join(WORKING_DIR, "pyinstaller"), ignore_errors=True)
 
-    if simple:
-        executable_name = "simple_ytdl"
-    else:
-        executable_name = f"simple_ytdl.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True, cwd=WORKING_DIR).strip()}"
+    usr_platform = sys.platform
+    usr_platform = "macos" if usr_platform == "darwin" else usr_platform
+
+    executable_name = "simple_ytdl_" + usr_platform
+
+    if not simple:
+        executable_name = f"{executable_name}.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True, cwd=WORKING_DIR).strip()}"
 
     subprocess.run(
         [


### PR DESCRIPTION
This pull request includes several updates to the configuration and build processes for the project, focusing on automation and platform-specific builds. The most important addition is a workflow that automatically creates a release draft with Windows, MacOS, and Linux binaries attached when a new tag is pushed. This workflow not only streamlines the process of releasing new versions, but it also means that we now support non-windows platforms!

### Configuration Updates:

* [`.github/dependabot.yml`](https://github.com/Jurassic001/simple_ytdl/pull/8/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28): Changed the update schedule from monthly to weekly.
* [`.github/release.yml`](https://github.com/Jurassic001/simple_ytdl/pull/8/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213): Added a new release configuration file to categorize changes.

### Build and Release Automation:

* [`.github/workflows/release-draft.yml`](https://github.com/Jurassic001/simple_ytdl/pull/8/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213): Created a new workflow to build and release the `simple_ytdl` executable for Windows, Ubuntu, and macOS when a tag is pushed.
* [`.github/workflows/label-precommit-prs.yml`](https://github.com/Jurassic001/simple_ytdl/pull/8/files#diff-ff4419bd184864bbde87cbffb1ff30bbf99168580a72b802fe796f023751d684): Automatically label pull requests by @pre-commit-ci

### Script Enhancements:

* [`scripts/build.py`](https://github.com/Jurassic001/simple_ytdl/pull/8/files#diff-c786cc346fc8fdc17f1c85f11bc187c153a3511ae549390185c7c39343d2c95d): Added platform detection to generate platform-specific executable names.