### PR TITLE
Update dependabot & changelog configs, and prune requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,22 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      default:
+      core:
+        patterns:
+          - pyperclip
+          - yt-dlp
+          - ffmpeg
+          - ffprobe
+      development:
+        patterns:
+          - pyinstaller
+          - pre-commit
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
         patterns:
           - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,10 +5,8 @@ changelog:
     - title: Major Changes
       labels:
         - enhancement
-        - major
     - title: Minor Changes
       labels:
-        - minor
         - refactor
         - documentation
     - title: Bugfixes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ffmpeg==1.4
 ffprobe==0.5
-keyboard==0.13.5
 pre-commit==4.0.1
 pyinstaller==6.10.0
 pyperclip==1.9.0


### PR DESCRIPTION
This pull request updates the dependabot configuration by adding the github-action ecosystem with the actions group and overhauling the grouping for the pip ecosystem. The core dependencies and development dependencies are now separated.
Also removed keyboard library from requirements.txt and bad labels from release changelog config