### PR TITLE
Fix bad implementation of yt-dlp in program execution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/* filter=lfs diff=lfs merge=lfs -text

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,7 @@ changelog:
     - title: Major Changes
       labels:
         - enhancement
+        - breaking
     - title: Minor Changes
       labels:
         - refactor

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -91,7 +91,7 @@ jobs:
   release:
     # Wait for all build jobs to complete, as long as none of them failed then we will create the draft release
     needs: [build-windows, build-linux, build-macos]
-    if: ${{ needs.build-windows.result != 'failure' && needs.build-linux.result != 'failure' && needs.build-macos.result != 'failure' }}
+    if: ${{ !failure() }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -89,7 +89,9 @@ jobs:
 
   # region Create a draft release
   release:
+    # Wait for all build jobs to complete, as long as none of them failed then we will create the draft release
     needs: [build-windows, build-linux, build-macos]
+    if: ${{ needs.build-windows.result != 'failure' && needs.build-linux.result != 'failure' && needs.build-macos.result != 'failure' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,5 +1,7 @@
-name: Build and Release (Windows, Ubuntu, macOS)
-# Build and release the simple_ytdl executable on Windows, Ubuntu, and macOS when a tag is pushed
+name: Build executable and Create draft release
+# Build and release the simple_ytdl executable when a tag is pushed
+# Executables will be built according to the values of the BUILD_WINDOWS, BUILD_LINUX, and BUILD_MACOS repository variables
+# Set repo variable values in Settings > Secrets and variables > Actions > Variables > Repository variables
 
 on:
   push:
@@ -9,6 +11,7 @@ on:
 jobs:
   # region Build Win exe
   build-windows:
+    if: ${{ vars.BUILD_WINDOWS == 'true' }}
     runs-on: windows-latest
 
     steps:
@@ -34,6 +37,7 @@ jobs:
 
   # region Build Linux exe
   build-linux:
+    if: ${{ vars.BUILD_LINUX == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -59,6 +63,7 @@ jobs:
 
   # region Build MacOS exe
   build-macos:
+    if: ${{ vars.BUILD_MACOS == 'true' }}
     runs-on: macos-latest
 
     steps:
@@ -89,16 +94,19 @@ jobs:
 
     steps:
     - name: Download Windows executable
+      if: ${{ vars.BUILD_WINDOWS == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_windows
 
     - name: Download Linux executable
+      if: ${{ vars.BUILD_LINUX == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_linux
 
     - name: Download MacOS executable
+      if: ${{ vars.BUILD_MACOS == 'true' }}
       uses: actions/download-artifact@v4
       with:
         name: simple_ytdl_macos
@@ -113,6 +121,6 @@ jobs:
         draft: true
         prerelease: false
         files: |
-          simple_ytdl_win32.exe
-          simple_ytdl_linux
-          simple_ytdl_macos
+          ${{ vars.BUILD_WINDOWS == 'true' && 'simple_ytdl_win32.exe' || '' }}
+          ${{ vars.BUILD_LINUX == 'true' && 'simple_ytdl_linux' || '' }}
+          ${{ vars.BUILD_MACOS == 'true' && 'simple_ytdl_macos' || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,5 @@ dist/
 build/
 *.spec
 
-# unused executables dir
-bin/
-
 # testing workflows will fail because Youtube flags the IP address as a bot
 .github/workflows/test-*.yml

--- a/README.md
+++ b/README.md
@@ -4,26 +4,20 @@
 [![GitHub Release](https://img.shields.io/github/v/release/Jurassic001/simple_ytdl?style=flat-square)](https://github.com/Jurassic001/simple_ytdl/releases/latest)
 [![GitHub License](https://img.shields.io/github/license/Jurassic001/simple_ytdl?style=flat-square)](LICENSE)
 
-### An easy-to-use, text-based program for downloading Youtube videos at high fidelity, utilizing [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [FFmpeg](https://www.ffmpeg.org).
+### An easy-to-use, text-based program for downloading Youtube videos at high quality, utilizing [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [FFmpeg](https://www.ffmpeg.org).
 
 ## How to use
 ### Requirements
-#### `Windows & MacOS`
-None! The executable file contains all the necessary dependencies to run the program.
-
-#### `Linux`
-You need to have `xclip` installed on your system. You can install it using the following command:
-```bash
-sudo apt-get install xclip
-```
+Unfortunately, this program is only available for Windows at the moment. Support for other operating systems, such as MacOS, is planned for the future. <br/>
 
 ### Installation
-Download the executable (.exe) file for your operating system in [releases](https://github.com/Jurassic001/simple_ytdl/releases/latest). <br/>
+Download the executable (.exe) file in [releases](https://github.com/Jurassic001/simple_ytdl/releases/latest). <br/>
 That's it! You can now run the program and easily download videos at high quality!
 
 ### Program Usage
 1. Copy the URL of the desired media and run the program.
-1. You can choose between .mp4 (video) or .mp3 (audio) format, and the content will be downloaded at 1080p (HD).
+1. Simply follow the prompts! The program will allow you to switch between downloading the entire Youtube video (.mp4), or just the audio (.mp3).
+    * Media will automatically be downloaded at the highest quality available.
     * Download locations are the `Videos` folder for .mp4s and the `Music` folder for .mp3s.
 1. The program will also warn you if you try to submit something that doesn't look like a URL (although you can ignore the warning).
 
@@ -44,6 +38,7 @@ I wanted to extend this simplicity to other users, so I redesigned this program 
 * Add a GUI to the program
 * Add more download location options
 * Add workflow tests (need to circumvent Youtube bot checks)
+* Add cross-platform support (major undertaking)
 
 ## Legal
 ### Disclaimer

--- a/bin/ffmpeg.exe
+++ b/bin/ffmpeg.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a59b638b49f8e6c622f4de7c4c8aaf8442f30138a58882ee2af3f410e5fd5c
+size 148103168

--- a/bin/yt-dlp.exe
+++ b/bin/yt-dlp.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdf3856b6392e9b96637229294993dae2331f2565fcdfc8cccada74927dc31bb
+size 18808332

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 import argparse
 import os
+import subprocess
 import sys
 import time
 
 import pyperclip
-import yt_dlp
 
 
 class simple_ytdl:
@@ -16,17 +16,29 @@ class simple_ytdl:
 
         self.clear = lambda: os.system("cls" if os.name == "nt" else "clear")  # Clear the console
 
+        self.ERROR_MSG: dict[type[Exception], str] = {
+            subprocess.TimeoutExpired: "Video search timed out",
+            subprocess.CalledProcessError: "Invalid URL or the video cannot be found",
+        }  # Dictionary of error messages that correspond to the exception
+
+        self.YTDL_PATH: str = os.path.join(os.path.dirname(__file__), "bin/yt-dlp.exe")  # Path to the yt-dlp executable
+        self.FFMPEG_PATH: str = os.path.join(os.path.dirname(__file__), "bin/ffmpeg.exe")  # Path to the ffmpeg executable
+
         self.isVideo: bool = True  # Download format: True - mp4, False - mp3
         self.skip_prompts: bool = skip  # Skip input prompts
         self.prompt_skip_val: str = skip_val  # Value to return when skipping prompts
 
-        if sys.platform == "win32":
-            pyperclip.set_clipboard("windows")
-        elif sys.platform == "linux":
-            pyperclip.set_clipboard("xclip")
-        elif sys.platform == "darwin":
-            pyperclip.set_clipboard("pbobjc")
-        else:  # Unsupported OS
+        # if sys.platform == "win32":
+        #     pyperclip.set_clipboard("windows")
+        # elif sys.platform == "linux":
+        #     pyperclip.set_clipboard("xclip")
+        # elif sys.platform == "darwin":
+        #     pyperclip.set_clipboard("pbobjc")
+        # else:  # Unsupported OS
+        #     print("Unsupported OS")
+        #     sys.exit(1)
+
+        if sys.platform != "win32":
             print("Unsupported OS")
             sys.exit(1)
 
@@ -54,19 +66,35 @@ class simple_ytdl:
             link (str): The URL of the media that you want to download
             vidName (str): The name of the media that you want to download
         """
-        # Print the name of the to-be downloaded video and its destination
         self.clear()
         targ_folder = "Videos" if self.isVideo else "Music"
+        default_cmd = [
+            "--ffmpeg-location",
+            self.FFMPEG_PATH,
+            "-o",
+            os.path.expanduser(f"~/{targ_folder}/%(title)s.%(ext)s"),
+            link,
+        ]
+        # Print the name of the to-be downloaded video and its destination
         print(f"Downloading: {vidName} to your {targ_folder} folder\n")
         # Let the user read the printed line before filling the console with status updates
         time.sleep(1)
-        # Start downloading the video
-        ydl_opts = {
-            "format": "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/b" if self.isVideo else "ba[ext=mp3]/b",
-            "outtmpl": os.path.expanduser(f"~/{'Videos' if self.isVideo else 'Music'}/%(title)s.%(ext)s"),
-        }
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            ydl.download([link])
+        # Setup media downloading command
+        if self.isVideo:
+            cmd = [
+                "--format",
+                "bv*[ext=mp4][fps<=60]+ba[ext=m4a]",
+            ]
+        else:
+            cmd = [
+                "--extract-audio",
+                "--audio-format",
+                "mp3",
+                "--audio-quality",
+                "0",
+            ]
+        # Run the download command
+        subprocess.run([self.YTDL_PATH] + cmd + default_cmd)
         self.input("\nPress Enter to exit the program")
         sys.exit(0)
 
@@ -79,19 +107,10 @@ class simple_ytdl:
         self.clear()
         print("Processing the URL...", end="\n\n")
         try:
-            title_check_options = {
-                "quiet": True,
-                "no_warnings": True,
-                "skip_download": True,
-                "force_generic_extractor": True,
-                "outtmpl": "%(title)s.%(ext)s",
-            }
-            with yt_dlp.YoutubeDL(title_check_options) as title_checker:
-                info_dict = title_checker.extract_info(link, download=False)
-                videoName: str = info_dict["title"].strip().strip(".")  # type: ignore
+            videoName = (subprocess.check_output([self.YTDL_PATH, "-O", '"%(title)s"', link], text=True, timeout=10)).strip()
         except Exception as e:
-            print(f"\nAn error occurred: {e}")
-            self.input(f"Press Enter to try again. ")
+            err_msg = self.ERROR_MSG.get(type(e), f"An unknown error occurred: {e}")
+            self.input(f"\n{err_msg}\n Press Enter to try again. ")
             return
         while True:
             self.clear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-ffmpeg==1.4
-ffprobe==0.5
 pre-commit==4.0.1
 pyinstaller==6.10.0
 pyperclip==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pre-commit==4.0.1
 pyinstaller==6.10.0
 pyperclip==1.9.0
-yt-dlp==2024.10.7

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import shutil
 import subprocess
-import sys
 
 WORKING_DIR: str = os.path.join(os.path.dirname(os.path.dirname(__file__)))
 
@@ -12,10 +11,11 @@ def build(clean: bool, simple: bool) -> None:
     if clean:
         shutil.rmtree(os.path.join(WORKING_DIR, "pyinstaller"), ignore_errors=True)
 
-    usr_platform = sys.platform
-    usr_platform = "macos" if usr_platform == "darwin" else usr_platform
+    # usr_platform = sys.platform
+    # usr_platform = "macos" if usr_platform == "darwin" else usr_platform
+    # executable_name = "simple_ytdl_" + usr_platform
 
-    executable_name = "simple_ytdl_" + usr_platform
+    executable_name = "simple_ytdl"
 
     if not simple:
         executable_name = f"{executable_name}.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True, cwd=WORKING_DIR).strip()}"
@@ -24,6 +24,10 @@ def build(clean: bool, simple: bool) -> None:
         [
             "pyinstaller",
             "--onefile",
+            "--add-binary",
+            f"{WORKING_DIR}/bin/yt-dlp.exe;bin",
+            "--add-binary",
+            f"{WORKING_DIR}/bin/ffmpeg.exe;bin",
             "--distpath",
             "./pyinstaller/dist",
             "--workpath",

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import sys
 
 WORKING_DIR: str = os.path.join(os.path.dirname(os.path.dirname(__file__)))
 
@@ -11,11 +12,9 @@ def build(clean: bool, simple: bool) -> None:
     if clean:
         shutil.rmtree(os.path.join(WORKING_DIR, "pyinstaller"), ignore_errors=True)
 
-    # usr_platform = sys.platform
-    # usr_platform = "macos" if usr_platform == "darwin" else usr_platform
-    # executable_name = "simple_ytdl_" + usr_platform
-
-    executable_name = "simple_ytdl"
+    usr_platform = sys.platform
+    usr_platform = "macos" if usr_platform == "darwin" else usr_platform
+    executable_name = "simple_ytdl_" + usr_platform
 
     if not simple:
         executable_name = f"{executable_name}.{subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True, cwd=WORKING_DIR).strip()}"

--- a/scripts/install_reqs.py
+++ b/scripts/install_reqs.py
@@ -74,6 +74,12 @@ def main(strict: bool) -> None:
         check=strict,
         cwd=ROOT_DIR,
     )
+    # Setup Git Large File System
+    subprocess.run(
+        ["git", "lfs", "install"],
+        check=strict,
+        cwd=ROOT_DIR,
+    )
     print_with_sidebars("Requirement installation/setup successful", GREEN)
     sys.exit(0)
 


### PR DESCRIPTION
The hallmark of this commit is reverting to the old approach (changed in #6) of yt-dlp and ffmpeg being implemented as binaries instead of Python libraries. The library approach ended up being unreliable, and we lost crucial support for FFmpeg, which we use to guarantee media quality standards during the downloading process.

So we're back to bundling yt-dlp and ffmpeg as binaries. This approach is not crossplatform compatable, so we have lost crossplatform support for the time being (assuming we ever had it, due to lackluster testing on my part).

Once again, we're managing binaries with git LFS (large file system). I've updated the README to reflect the changes, and I also overhauled the Program Usage section.

Scripts have regained their binary-specific functions after they were previously removed. Updated requirements.txt and .gitignore to reflect binary re-implementation.

Finally, the release-draft workflow has been updated to allow me to manage which Operating Systems the program executable is built and released for, using repository variables. The changelog config has also been updated to include the `breaking` label.