### PR TITLE
Refactor dependabot config to produce better dependency version update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,22 +7,15 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      core:
+      Python:
         patterns:
-          - pyperclip
-          - yt-dlp
-          - ffmpeg
-          - ffprobe
-      development:
-        patterns:
-          - pyinstaller
-          - pre-commit
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      actions:
+      GitHub-Actions:
         patterns:
           - "*"


### PR DESCRIPTION
Unite ALL version updates for github-actions and pip ecosystems under formatted groups, in order to increase clarity in pull requests and cover all bases when it comes to dependency management