### PR TITLE
Fix bug when compiling using release-draft workflow

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -12,7 +12,7 @@ jobs:
   # region Build Win exe
   build-windows:
     if: ${{ vars.BUILD_WINDOWS == 'true' }}
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_windows
-        path: ./pyinstaller/dist/simple_ytdl_win32.exe
+        path: ./pyinstaller
 
   # region Build Linux exe
   build-linux:
@@ -59,7 +59,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_linux
-        path: ./pyinstaller/dist/simple_ytdl_linux
+        path: ./pyinstaller
 
   # region Build MacOS exe
   build-macos:
@@ -85,7 +85,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: simple_ytdl_macos
-        path: ./pyinstaller/dist/simple_ytdl_macos
+        path: ./pyinstaller
 
   # region Create a draft release
   release:
@@ -123,6 +123,6 @@ jobs:
         draft: true
         prerelease: false
         files: |
-          ${{ vars.BUILD_WINDOWS == 'true' && 'simple_ytdl_win32.exe' || '' }}
-          ${{ vars.BUILD_LINUX == 'true' && 'simple_ytdl_linux' || '' }}
-          ${{ vars.BUILD_MACOS == 'true' && 'simple_ytdl_macos' || '' }}
+          ${{ vars.BUILD_WINDOWS == 'true' && 'dist/simple_ytdl_win32.exe' || '' }}
+          ${{ vars.BUILD_LINUX == 'true' && 'dist/simple_ytdl_linux' || '' }}
+          ${{ vars.BUILD_MACOS == 'true' && 'dist/simple_ytdl_macos' || '' }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Install Python Packages
+    - name: Install Dependencies
       run: python scripts/install_reqs.py
 
     - name: Build simple_ytdl.exe
@@ -53,7 +53,7 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Install Python Packages
+    - name: Install Dependencies
       run: python scripts/install_reqs.py
 
     - name: Build simple_ytdl
@@ -81,7 +81,7 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Install Python Packages
+    - name: Install Dependencies
       run: python scripts/install_reqs.py
 
     - name: Build simple_ytdl

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        lfs: "true"
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -43,6 +45,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        lfs: "true"
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -69,6 +73,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        lfs: "true"
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -12,7 +12,7 @@ jobs:
   # region Build Win exe
   build-windows:
     if: ${{ vars.BUILD_WINDOWS == 'true' }}
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout repository

--- a/scripts/install_reqs.py
+++ b/scripts/install_reqs.py
@@ -80,6 +80,12 @@ def main(strict: bool) -> None:
         check=strict,
         cwd=ROOT_DIR,
     )
+    # Pull LFS files
+    subprocess.run(
+        ["git", "lfs", "pull"],
+        check=strict,
+        cwd=ROOT_DIR,
+    )
     print_with_sidebars("Requirement installation/setup successful", GREEN)
     sys.exit(0)
 


### PR DESCRIPTION
This pull request fixes a major bug in the `release-draft` workflow that caused simple_ytdl executables to be built without the required yt-dlp and ffmpeg binaries. This was due to the fact that I had not enabled git large file system during the `Checkout repository` step of the workflow, so binaries were not being downloaded and bundled into the executable. I've fixed this issue in the workflow and incorporated a similar change into the `install_reqs` script as well.

I've also made a few other changes:
- Upload the entire pyinstaller directory as an artifact, which lets me download the entire thing if I go into the workflow logs. The executable is still the only thing uploaded to the draft release. This change helps with debugging workflow issues and only increases workflow execution time by about 5 seconds.
- Renamed the `Install Python Packages` step in the release-draft workflow to `Install Dependencies`, to better represent what the step actually does.