### PR TITLE
Update build/release Python version to 3.12

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install Dependencies
       run: python scripts/install_reqs.py
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install Dependencies
       run: python scripts/install_reqs.py
@@ -79,7 +79,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install Dependencies
       run: python scripts/install_reqs.py


### PR DESCRIPTION
I've been running an executable built on Python 3.12 on my personal laptop for a few months now, and I can't find any issues with the version change. Thus, I'm thinking it's time I release this change as official.

With this change, newly built executables will be compiled for Python 3.12